### PR TITLE
fix: os.tmpDir -> os.tmpdir

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = repoUrl;
 
 var client = new Client({
   registry: 'http://registry.npmjs.org/',
-  cache: os.tmpDir() + '/git-url'
+  cache: os.tmpdir() + '/git-url'
 });
 
 function repoUrl (module, fn) {


### PR DESCRIPTION
This PR updates a deprecated method name.

Getting the following warning whenever I use `npm-clone`, which depends on this module.

```
(node:11425) DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.
```

Simply updating `tmpDir` to `tmpdir` to get rid of the warning.